### PR TITLE
Clean up README current-state wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ The verifier builds release archives, validates the manifest and setup job contr
 
 ## Init And Sample Jobs
 
-The source service set includes:
+The packaged setup contract includes:
 
 - `typedb-init`: one-shot TypeQL schema/database creation through the TypeDB console
 - `typedb-sample`: one-shot Python sample-data upload after schema initialization
 
-Those are now implemented as manual `setup.steps` on the `typedb` service, not as managed daemons. The packaged scripts preserve the donor file contract (`init.tql.template`, `schema.tql`, `requirements.txt`, `basic_upload.py`, `basic_logs.py`, `data/`, and `schema/`) while moving execution into Service Lasso's setup lifecycle.
+These are implemented as manual `setup.steps` on the `typedb` service, not as managed daemons. The packaged scripts include the expected setup assets (`init.tql.template`, `schema.tql`, `requirements.txt`, `basic_upload.py`, `basic_logs.py`, `data/`, and `schema/`) and run through Service Lasso's setup lifecycle.
 
 See [docs/job-boundary.md](docs/job-boundary.md).


### PR DESCRIPTION
## Intent
Clean up README wording so the project page describes the current Service Lasso service state instead of local machine paths or historical donor/reference context.

## Change
- Remove machine-local source paths from README content.
- Replace donor/history phrasing with current service contracts and user-facing wording.
- Keep useful runtime, release, and verification information intact.

## Verification
- README sweep for `C:\projects`, `C:/projects`, `donor`, `copied from`, `replaces the old`, `source reference`, and `reference implementation` returned clean.
- `git diff --check`

## Risk
Docs-only. No runtime or packaging behavior changes.